### PR TITLE
Reduce the FW version back to 5.2.

### DIFF
--- a/conf_general.h
+++ b/conf_general.h
@@ -21,10 +21,10 @@
 #define CONF_GENERAL_H_
 
 // Firmware version
-#define FW_VERSION_MAJOR 6
-#define FW_VERSION_MINOR 0
+#define FW_VERSION_MAJOR 5
+#define FW_VERSION_MINOR 2
 // Set to 0 for building a release and iterate during beta test builds
-#define FW_TEST_VERSION_NUMBER 0
+#define FW_TEST_VERSION_NUMBER 1
 
 #include "datatypes.h"
 


### PR DESCRIPTION
Increment the test version number to 1.
FW versions higher than 5.2 are not supported by the VESC tool, causing it to run in limited mode.